### PR TITLE
:package: Update Deno dependencies

### DIFF
--- a/deps_test.ts
+++ b/deps_test.ts
@@ -1,5 +1,5 @@
 export { expect } from "https://deno.land/x/expect@v0.2.9/mod.ts";
-export * from "https://deno.land/std@0.109.0/testing/asserts.ts";
+export * from "https://deno.land/std@0.110.0/testing/asserts.ts";
 
 const currentScopes: string[] = [];
 


### PR DESCRIPTION
The output of `make update` is

```
./utils.ts

./types.ts

./deps_test.ts
[1/2] Looking for releases: https://deno.land/x/expect@v0.2.9/mod.ts
[1/2] Using latest: https://deno.land/x/expect@v0.2.9/mod.ts
[2/2] Looking for releases: https://deno.land/std@0.109.0/testing/asserts.ts
[2/2] Attempting update: https://deno.land/std@0.109.0/testing/asserts.ts -> 0.110.0
[2/2] Update successful: https://deno.land/std@0.109.0/testing/asserts.ts -> 0.110.0

./itertools.test.ts

./more-itertools.ts

./mod.ts

./builtins.test.ts

./custom.test.ts

./custom.ts

./itertools.ts

./more-itertools.test.ts

./builtins.ts

Already latest version:
https://deno.land/x/expect@v0.2.9/mod.ts == v0.2.9

Successfully updated:
https://deno.land/std@0.109.0/testing/asserts.ts 0.109.0 -> 0.110.0
make[1]: Entering directory '/home/runner/work/deno-itertools/deno-itertools'
make[1]: Leaving directory '/home/runner/work/deno-itertools/deno-itertools'

```